### PR TITLE
Cola

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@ roxygen2.*[.]R
 install-rgraphviz.sh
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^netmeta\.Rproj$


### PR DESCRIPTION
[construct manual model matrix in netmetareg to allow character and factor covariates. update res to incorporate original treatment names in addition to treatment abbreviations. update print method to show reference covariate levels for all non-continuous covariates. update variable assignment for compatibility with the calcV function. It also includes corrects the assignment of time2, harmonizes the manual design matrix for all assumptions, and updates the print output for NMA