### PR TITLE
SMD and Incr fixes

### DIFF
--- a/R/netmeta-internal.R
+++ b/R/netmeta-internal.R
@@ -95,8 +95,11 @@ calcV <- function(x, sm) {
   else if (sm == "IRSD")
     V <- matrix(0.25 / x$time2[1],
                 nrow = nrow(x), ncol = nrow(x))
-  else
-    V <- diag(x$seTE^2)
+  else if(nrow(x)==1){
+    V <- as.matrix(x$seTE^2)# 2arm SMDs and other non-listed sms
+  } else {
+    V <- diag(x$seTE^2) # # multi-arm SMDs and other non-listed sms
+  }
   #
   diag(V) <- x$seTE^2
   ##

--- a/R/netmetareg-internal.R
+++ b/R/netmetareg-internal.R
@@ -253,7 +253,7 @@ nmr_full_results <- function(x) {
       #
       # Covariances
       #
-      Cov_d_beta <- Cov[!sel.d, sel.d, drop = FALSE]
+      Cov_d_beta <- Cov[!sel.d, sel.d]
       #
       all_se.beta <- dat_d %>% select(comparison) %>% mutate(cov.default = 0)
       #

--- a/R/netmetareg.R
+++ b/R/netmetareg.R
@@ -231,8 +231,8 @@ netmetareg.netmeta <- function(x, covar = NULL,
     available.times <- TRUE
   }
   #
-  if (!is.null(x$data$.incr1) & !is.null(x$data$.incr2)) {
-    dat$incr1 <- x$data$.incr1
+  if (!is.null(x$data$incr1) & !is.null(x$data$.incr2)) {
+    dat$incr1 <- x$data$incr1
     dat$incr2 <- x$data$.incr2
   }
   #


### PR DESCRIPTION
update calcV to enable SMDs when using REML estimator
Avoid error message in common assumption results
update .incr1 to incr1, because the netmeta object does not always have a .incr1 variable